### PR TITLE
Fix duplicate column bug in schema introspection

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -87,6 +87,7 @@ def discover_catalog(conn, db_schema):
         c.is_nullable
         FROM INFORMATION_SCHEMA.Tables t
         JOIN INFORMATION_SCHEMA.Columns c ON c.table_name = t.table_name
+            AND c.table_schema = t.table_schema
         WHERE t.table_schema = '{}'
         ORDER BY c.table_name, c.ordinal_position
         """.format(db_schema))


### PR DESCRIPTION
We have tables with identical names in different schemas. That's causing the introspection to return duplicate columns and sometimes with the wrong data type. 

@MortenHegewald 